### PR TITLE
(dev-4126) Redesign I Ajustar o scroll das tabs que está cortando os textos

### DIFF
--- a/src/scss/components/_tabs.scss
+++ b/src/scss/components/_tabs.scss
@@ -1,5 +1,4 @@
 .tabs-header {
-  display: inline-flex;
   border-radius: 10px;
   padding: 0.5rem;
   background: var(--white);


### PR DESCRIPTION
- [dev-4126](https://duopana.myjetbrains.com/youtrack/issue/dev-4126) Redesign I Ajustar o scroll das tabs que está cortando os textos

O problema acontece com width abaixo de 455px.